### PR TITLE
Add auto deploy of docs to github pages

### DIFF
--- a/.github/workflows
+++ b/.github/workflows
@@ -17,7 +17,7 @@ jobs:
         run: |
           cd docs
           pip install pygments
-          ./doc-generator.py
+          python doc-generator.py
       -
         name: Deploy to GitHub Pages
         if: success()

--- a/.github/workflows
+++ b/.github/workflows
@@ -17,7 +17,7 @@ jobs:
         run: |
           cd docs
           pip install pygments
-          python doc-generator.py
+          python3 doc-generator.py
       -
         name: Deploy to GitHub Pages
         if: success()

--- a/.github/workflows
+++ b/.github/workflows
@@ -1,0 +1,26 @@
+name: docs
+
+on: push
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Gen dummy page
+        run: |
+          cd docs
+          pip install pygments
+          ./doc-generator.py
+      -
+        name: Deploy to GitHub Pages
+        if: success()
+        uses: crazy-max/ghaction-github-pages@v2
+        with:
+          target_branch: gh-pages
+          build_dir: docs
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows
+++ b/.github/workflows
@@ -1,6 +1,9 @@
 name: docs
 
-on: push
+on:
+  push:
+    branches:
+      - master
 
 jobs:
   publish:

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 # Custom
-docs.html
+index.html
 
 # Byte-compiled / optimized / DLL files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -34,5 +34,5 @@ simply call
 python3 game.py
 ```
 
-To modify the game, open game.py and make your own changes
+To modify the game, open game.py and make your own changes.
 

--- a/README.md
+++ b/README.md
@@ -12,10 +12,6 @@ First off, clone the repository and `cd` into it.
 # With HTTPS
 git clone https://github.com/lithekod/snake-ribs.git
 cd snake-ribs
-
-# Or with ssh
-git clone git@github.com:lithekod/snake-ribs.git
-cd snake-ribs
 ```
 
 Running snake-ribs requires pygame, which can be installed using the following
@@ -25,10 +21,18 @@ command.
 pip install -r requirements.txt
 ```
 
-With pygame installed, run the game with:
+## Documentation
+
+The documentation for RIBS can be found at [tbd]
+
+## Running the game
+
+RIBS comes with a sample game which you can modify to make it your own. To run it,
+simply call
 
 ```bash
 python3 game.py
 ```
 
-Now you are ready to create your game!
+To modify the game, open game.py and make your own changes
+

--- a/docs/doc-generator.py
+++ b/docs/doc-generator.py
@@ -105,7 +105,7 @@ pg_docs = parse_docs("pygame.docs")
 sr_docs = parse_docs("ribs.docs")
 
 toc = gen_table_of_content(pg_docs, sr_docs)
-with open("docs.html", "w+") as f:
+with open("index.html", "w+") as f:
     intro = "<h1>TODO INTRO</h1>"
     f.write("<!--- This file is auto generated, please do not edit -->")
     f.write(f"<html><head><title>Documentation</title><style>{style}</style></head><body>")


### PR DESCRIPTION
I have no idea if I did this correctly, this is my first time using GH actions and I just copy pasted stuff, but in theory, it should build the documentation for the engine and deploy that to gh-pages. To make things convenient, I renamed docs.html to index.html